### PR TITLE
Fix PoseStamped frame_id

### DIFF
--- a/cisst_ros_bridge/src/mtsCISSTToROS.cpp
+++ b/cisst_ros_bridge/src/mtsCISSTToROS.cpp
@@ -196,7 +196,7 @@ bool mtsCISSTToROS(const prmPositionCartesianGet & cisstData, geometry_msgs::Pos
                    const std::string & debugInfo)
 {
     if (mtsCISSTToROSHeader(cisstData, rosData, debugInfo)) {
-        rosData.header.frame_id = cisstData.MovingFrame();
+        rosData.header.frame_id = cisstData.ReferenceFrame();
         mtsCISSTToROSPose(cisstData.Position(), rosData.pose);
         return true;
     }


### PR DESCRIPTION
Fixed the frame_id assignment in ```bool mtsCISSTToROS(..., geometry_msgs::PoseStamped & rosData, ...). ```
The frame_id should be the Reference Frame, not the Moving Frame.